### PR TITLE
Feat: 주문 단건 & 페이징 목록 조회 구현

### DIFF
--- a/src/main/java/com/example/ddakdaegi/domain/image/ImageRepository.java
+++ b/src/main/java/com/example/ddakdaegi/domain/image/ImageRepository.java
@@ -1,0 +1,8 @@
+package com.example.ddakdaegi.domain.image;
+
+import com.example.ddakdaegi.domain.image.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+
+}

--- a/src/main/java/com/example/ddakdaegi/domain/image/entity/Image.java
+++ b/src/main/java/com/example/ddakdaegi/domain/image/entity/Image.java
@@ -2,7 +2,13 @@ package com.example.ddakdaegi.domain.image.entity;
 
 import com.example.ddakdaegi.domain.image.enums.ImageType;
 import com.example.ddakdaegi.global.common.entity.Timestamped;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,13 +17,19 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Image extends Timestamped {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
-    @Column(nullable = false)
-    private String imageUrl;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @Enumerated(EnumType.STRING)
-    private ImageType type;
+	@Column(nullable = false)
+	private String imageUrl;
+
+	@Enumerated(EnumType.STRING)
+	private ImageType type;
+
+	public Image(String imageUrl, ImageType type) {
+		this.imageUrl = imageUrl;
+		this.type = type;
+	}
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
@@ -1,13 +1,19 @@
 package com.example.ddakdaegi.domain.order.controller;
 
 import com.example.ddakdaegi.domain.order.dto.request.CreateOrderRequest;
+import com.example.ddakdaegi.domain.order.dto.response.OrderDetailResponse;
 import com.example.ddakdaegi.domain.order.dto.response.OrderResponse;
 import com.example.ddakdaegi.domain.order.service.OrderService;
 import com.example.ddakdaegi.global.common.dto.AuthUser;
 import com.example.ddakdaegi.global.common.response.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,8 +33,21 @@ public class OrderController {
 	) {
 
 		OrderResponse orderResponse =
-			orderService.createOrder(authUser, request.getPromotionProductDtos());
+			orderService.createOrder(authUser, request.getPromotionProductRequests());
 		return Response.of(orderResponse);
 	}
 
+	@GetMapping("/v1/orders/{orderId}")
+	public Response<OrderDetailResponse> getOrder(@PathVariable Long orderId,
+		@AuthenticationPrincipal AuthUser authUser) {
+		return Response.of(orderService.getOrder(orderId, authUser));
+	}
+
+	@GetMapping("/v1/orders")
+	public Response<Page<OrderResponse>> getAllOrders(
+		@AuthenticationPrincipal AuthUser authUser,
+		@PageableDefault Pageable pageable
+	) {
+		return Response.of(orderService.getAllOrders(authUser, pageable));
+	}
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/dto/request/CreateOrderRequest.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/dto/request/CreateOrderRequest.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateOrderRequest {
 
-	private List<PromotionProductDto> promotionProductDtos;
+	private List<PromotionProductRequest> promotionProductRequests;
 
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/dto/request/PromotionProductRequest.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/dto/request/PromotionProductRequest.java
@@ -7,9 +7,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class PromotionProductDto {
+public class PromotionProductRequest {
 
 	private Long promotionProductId;
-	private Long promotionProductPrice;
 	private Long quantity;
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderDetailResponse.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderDetailResponse.java
@@ -1,0 +1,39 @@
+package com.example.ddakdaegi.domain.order.dto.response;
+
+import com.example.ddakdaegi.domain.member.entity.Member;
+import com.example.ddakdaegi.domain.order.entity.Order;
+import com.example.ddakdaegi.domain.order.entity.OrderPromotionProduct;
+import com.example.ddakdaegi.domain.order.enums.OrderStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class OrderDetailResponse {
+
+	private final Long orderId;
+	private final String email;
+	private final String address;
+	private final List<OrderPromotionProductDto> orderPromotionProducts;
+	private final Long totalPrice;
+	private final OrderStatus status;
+	private final LocalDateTime orderCompletionTime;
+
+	private OrderDetailResponse(Order order, Member member, List<OrderPromotionProduct> orderPromotionProducts) {
+		this.orderId = order.getId();
+		this.email = member.getEmail();
+		this.address = member.getAddress();
+		this.orderPromotionProducts = orderPromotionProducts.stream()
+			.map(OrderPromotionProductDto::of)
+			.toList();
+		this.totalPrice = order.getTotalPrice();
+		this.status = order.getStatus();
+		this.orderCompletionTime = order.getCreatedAt();
+	}
+
+	public static OrderDetailResponse of(Order order, Member member,
+		List<OrderPromotionProduct> orderPromotionProducts) {
+		return new OrderDetailResponse(order, member, orderPromotionProducts);
+	}
+
+}

--- a/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderPromotionProductDto.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderPromotionProductDto.java
@@ -1,19 +1,19 @@
 package com.example.ddakdaegi.domain.order.dto.response;
 
 import com.example.ddakdaegi.domain.order.entity.OrderPromotionProduct;
-import com.example.ddakdaegi.domain.promotion.entity.PromotionProduct;
+import com.example.ddakdaegi.domain.promotion.dto.response.PromotionProductDto;
 import lombok.Getter;
 
 @Getter
 public class OrderPromotionProductDto {
 
 	private final Long orderPromotionProductId;
-	private final PromotionProduct promotionProduct;
+	private final PromotionProductDto promotionProduct;
 	private final Long quantity;
 
-	private OrderPromotionProductDto(OrderPromotionProduct orderPromotionProduct) {
+	public OrderPromotionProductDto(OrderPromotionProduct orderPromotionProduct) {
 		this.orderPromotionProductId = orderPromotionProduct.getId();
-		this.promotionProduct = orderPromotionProduct.getPromotionProduct();
+		this.promotionProduct = PromotionProductDto.of(orderPromotionProduct);
 		this.quantity = orderPromotionProduct.getQuantity();
 	}
 

--- a/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderResponse.java
@@ -11,22 +11,30 @@ import lombok.Getter;
 public class OrderResponse {
 
 	private final Long orderId;
-	private final List<OrderPromotionProductDto> orderPromotionProducts;
+	private final List<OrderPromotionProductDto> orderPromotionProductDtos;
 	private final Long totalPrice;
 	private final OrderStatus status;
 	private final LocalDateTime orderCompletionTime;
 
-	private OrderResponse(Order order, List<OrderPromotionProduct> orderPromotionProducts) {
-		this.orderId = order.getId();
-		this.orderPromotionProducts = orderPromotionProducts.stream()
-			.map(OrderPromotionProductDto::of)
-			.toList();
-		this.totalPrice = order.getTotalPrice();
-		this.status = order.getStatus();
-		this.orderCompletionTime = LocalDateTime.now();
+	public OrderResponse(Long orderId, List<OrderPromotionProductDto> orderPromotionProductDtos, Long totalPrice,
+		OrderStatus status, LocalDateTime orderCompletionTime) {
+		this.orderId = orderId;
+		this.orderPromotionProductDtos = orderPromotionProductDtos;
+		this.totalPrice = totalPrice;
+		this.status = status;
+		this.orderCompletionTime = orderCompletionTime;
 	}
 
 	public static OrderResponse of(Order order, List<OrderPromotionProduct> orderPromotionProducts) {
-		return new OrderResponse(order, orderPromotionProducts);
+		List<OrderPromotionProductDto> orderPromotionProductDtos =
+			orderPromotionProducts.stream().map(OrderPromotionProductDto::of).toList();
+
+		return new OrderResponse(
+			order.getId(), orderPromotionProductDtos, order.getTotalPrice(), order.getStatus(), order.getCreatedAt());
+	}
+
+	public static OrderResponse ofDto(Order order, List<OrderPromotionProductDto> orderPromotionProductDtos) {
+		return new OrderResponse(
+			order.getId(), orderPromotionProductDtos, order.getTotalPrice(), order.getStatus(), order.getCreatedAt());
 	}
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderPromotionProductRepository.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderPromotionProductRepository.java
@@ -1,8 +1,12 @@
 package com.example.ddakdaegi.domain.order.repository;
 
 import com.example.ddakdaegi.domain.order.entity.OrderPromotionProduct;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface OrderPromotionProductRepository extends JpaRepository<OrderPromotionProduct, Long> {
 
+	@Query("select opp from OrderPromotionProduct opp where opp.order.id in :orderId")
+	List<OrderPromotionProduct> findByOrderId(Long orderId);
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderRepository.java
@@ -1,8 +1,13 @@
 package com.example.ddakdaegi.domain.order.repository;
 
 import com.example.ddakdaegi.domain.order.entity.Order;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 
+	@Query("select o from Order o where o.id = :orderId and o.member.id = :memberId")
+	Optional<Order> findByOrderIdAndMemberId(@Param("orderId") Long orderId, @Param("memberId") Long memberId);
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.ddakdaegi.domain.order.repository;
+
+import com.example.ddakdaegi.domain.order.dto.response.OrderResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface OrderRepositoryCustom {
+
+	Page<OrderResponse> findOrders(Long memberId, Pageable pageable);
+}

--- a/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderRepositoryCustomImpl.java
@@ -1,0 +1,69 @@
+package com.example.ddakdaegi.domain.order.repository;
+
+import com.example.ddakdaegi.domain.order.dto.response.OrderPromotionProductDto;
+import com.example.ddakdaegi.domain.order.dto.response.OrderResponse;
+import com.example.ddakdaegi.domain.order.entity.Order;
+import com.example.ddakdaegi.domain.promotion.dto.response.PromotionProductDto;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import static com.example.ddakdaegi.domain.order.entity.QOrder.order;
+import static com.example.ddakdaegi.domain.order.entity.QOrderPromotionProduct.orderPromotionProduct;
+
+@Service
+@RequiredArgsConstructor
+public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<OrderResponse> findOrders(Long memberId, Pageable pageable) {
+		List<Order> orders = queryFactory
+			.selectFrom(order)
+			.where(order.member.id.eq(memberId))
+			.orderBy(order.createdAt.desc())
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long totalCount = queryFactory
+			.select(order.count())
+			.from(order)
+			.where(order.member.id.eq(memberId))
+			.fetchOne();
+
+		List<OrderResponse> content = orders.stream()
+			.map(o -> {
+				List<OrderPromotionProductDto> orderPromotionProductDtos = queryFactory
+					.select(
+						Projections.constructor(
+							OrderPromotionProductDto.class,
+							orderPromotionProduct.id,
+							Projections.constructor(
+								PromotionProductDto.class,
+								orderPromotionProduct.promotionProduct.id,
+								orderPromotionProduct.promotionProduct.product.name,
+								orderPromotionProduct.promotionProduct.product.image,
+								orderPromotionProduct.promotionProduct.product.price
+							),
+							orderPromotionProduct.quantity
+						)
+					)
+					.from(orderPromotionProduct)
+					.where(orderPromotionProduct.order.id.eq(o.getId()))
+					.fetch();
+
+				return OrderResponse.ofDto(o, orderPromotionProductDtos);
+			}).collect(Collectors.toList());
+
+		return new PageImpl<>(content, pageable, totalCount != null ? totalCount : 0);
+	}
+
+}

--- a/src/main/java/com/example/ddakdaegi/domain/promotion/dto/response/PromotionProductDto.java
+++ b/src/main/java/com/example/ddakdaegi/domain/promotion/dto/response/PromotionProductDto.java
@@ -1,0 +1,31 @@
+package com.example.ddakdaegi.domain.promotion.dto.response;
+
+import com.example.ddakdaegi.domain.order.entity.OrderPromotionProduct;
+import com.example.ddakdaegi.domain.promotion.entity.PromotionProduct;
+import lombok.Getter;
+
+@Getter
+public class PromotionProductDto {
+
+	private final Long promotionProductId;
+	private final String productName;
+	private final String productImage;
+	private final Long price;
+
+	public PromotionProductDto(Long promotionProductId, String productName, String productImage, Long price) {
+		this.promotionProductId = promotionProductId;
+		this.productName = productName;
+		this.productImage = productImage;
+		this.price = price;
+	}
+
+	public static PromotionProductDto of(OrderPromotionProduct orderPromotionProduct) {
+		PromotionProduct promotionProduct = orderPromotionProduct.getPromotionProduct();
+		return new PromotionProductDto(
+			promotionProduct.getId(),
+			promotionProduct.getProduct().getName(),
+			promotionProduct.getProduct().getImage().getImageUrl(),
+			promotionProduct.getPrice()
+		);
+	}
+}

--- a/src/test/java/com/example/ddakdaegi/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/ddakdaegi/domain/order/service/OrderServiceTest.java
@@ -6,7 +6,7 @@ import com.example.ddakdaegi.domain.image.enums.ImageType;
 import com.example.ddakdaegi.domain.member.entity.Member;
 import com.example.ddakdaegi.domain.member.enums.UserRole;
 import com.example.ddakdaegi.domain.member.repository.MemberRepository;
-import com.example.ddakdaegi.domain.order.dto.request.PromotionProductDto;
+import com.example.ddakdaegi.domain.order.dto.request.PromotionProductRequest;
 import com.example.ddakdaegi.domain.product.entity.Product;
 import com.example.ddakdaegi.domain.product.repository.ProductRepository;
 import com.example.ddakdaegi.domain.promotion.entity.Promotion;
@@ -93,9 +93,7 @@ public class OrderServiceTest {
 		AtomicInteger successCount = new AtomicInteger(0);
 		AtomicInteger failedCount = new AtomicInteger(0);
 
-		List<PromotionProductDto> productDtos = List.of(
-			new PromotionProductDto(promotionProduct.getId(), promotionProduct.getPrice(), 1L)
-		);
+		List<PromotionProductRequest> productDtos = List.of(new PromotionProductRequest(promotionProduct.getId(), 1L));
 
 		for (int i = 0; i < threadCount; i++) {
 			executorService.execute(() -> {


### PR DESCRIPTION
## 📌 PR 요약
- 주문 단건 & 페이징 목록 조회 구현

## 🔗 관련 이슈
- ref #3

## 🛠️ 변경 사항
- 테스트 코드 내 컴파일 에러를 막기 위해 `Image` 엔티티 내 생성자 및 `ImageRepository` 생성
- 단건 조회와 페이징 목록 조회를 위해 필요한 클래스 생성
- 페이징 목록 조회의 경우 Querydsl로 구현함

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

| 기능 | 스크린샷 |
| --- | --- |
| 주문 단건 조회 | ![스크린샷 2025-03-27 213353](https://github.com/user-attachments/assets/16e59c7a-3834-4d92-b0ac-9f38b6a9aa1f) |
| 주문 페이징 목록 조회 | ![스크린샷 2025-03-27 224058](https://github.com/user-attachments/assets/f3e1efcd-9ade-4028-a0d8-73818ad5ee53) |

## ⚠️ 주의 사항 (선택)


## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.