### PR TITLE
Feat: 주문 취소 구현

### DIFF
--- a/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -49,5 +50,10 @@ public class OrderController {
 		@PageableDefault Pageable pageable
 	) {
 		return Response.of(orderService.getAllOrders(authUser, pageable));
+	}
+
+	@PatchMapping("/v1/orders/{orderId}")
+	public void cancelOrder(@PathVariable Long orderId, @AuthenticationPrincipal AuthUser authUser) {
+		orderService.cancelOrder(orderId, authUser);
 	}
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/entity/Order.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/entity/Order.java
@@ -46,4 +46,8 @@ public class Order extends Timestamped {
 	public static Order of(Member member, Long totalPrice) {
 		return new Order(member, totalPrice);
 	}
+
+	public void cancelOrder() {
+		this.status = OrderStatus.CANCELED;
+	}
 }

--- a/src/main/java/com/example/ddakdaegi/domain/product/entity/Product.java
+++ b/src/main/java/com/example/ddakdaegi/domain/product/entity/Product.java
@@ -3,12 +3,19 @@ package com.example.ddakdaegi.domain.product.entity;
 import com.example.ddakdaegi.domain.image.entity.Image;
 import com.example.ddakdaegi.domain.member.entity.Member;
 import com.example.ddakdaegi.global.common.entity.Timestamped;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "product")
@@ -64,4 +71,7 @@ public class Product extends Timestamped {
 		this.soldOut = false; // 기본 값
 	}
 
+	public void revertStock(Long quantity) {
+		this.stock += quantity;
+	}
 }

--- a/src/main/java/com/example/ddakdaegi/domain/promotion/entity/PromotionProduct.java
+++ b/src/main/java/com/example/ddakdaegi/domain/promotion/entity/PromotionProduct.java
@@ -62,4 +62,8 @@ public class PromotionProduct extends Timestamped {
 	public void decreaseStock(Long quantity) {
 		this.stock -= quantity;
 	}
+
+	public void revertStock(Long quantity) {
+		this.stock += quantity;
+	}
 }


### PR DESCRIPTION
## 📌 PR 요약
- 주문 취소 구현

## 🔗 관련 이슈
- closed #3

## 🛠️ 변경 사항
- 주문 취소 시 프로모션의 `isActive`에 따라 진행 중(true)일 경우 `PromotionProduct`의 `stock`을 구매한 개수만큼 되돌리고, 이미 종료(false)되었을 경우 `Product`의 `stock`을 구매한 만큼 되돌리도록 함
- `Product`, `PromotionProduct`에 개수를 되돌리는 `revertStock()` 메서드 생성함

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

| 기능 | 스크린샷 |
| --- | --- |
| 주문 취소 결과 | ![스크린샷 2025-03-27 224145](https://github.com/user-attachments/assets/7f674c1b-a9e4-402d-a963-57ee55b90014) |

## ⚠️ 주의 사항 (선택)

- 다른 도메인의 ErrorCode가 아직 정의되지 않아서 `RuntimeException`을 던지고 있습니다.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.