### PR TITLE
Refactor: 동시성 제어 - DB Lock

### DIFF
--- a/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
@@ -35,8 +35,8 @@ public class OrderController {
 		@AuthenticationPrincipal AuthUser authUser,
 		@Valid @RequestBody CreateOrderRequest request
 	) {
-		StockResponse stockResponse = stockService.decreaseStockAndCalculateTotalPrice(
-			request.getPromotionProductRequests());
+		StockResponse stockResponse =
+			stockService.decreaseStockAndCalculateTotalPrice(request.getPromotionProductRequests());
 
 		OrderResponse orderResponse =
 			orderService.createOrder(authUser, stockResponse);
@@ -44,8 +44,10 @@ public class OrderController {
 	}
 
 	@GetMapping("/v1/orders/{orderId}")
-	public Response<OrderDetailResponse> getOrder(@PathVariable Long orderId,
-		@AuthenticationPrincipal AuthUser authUser) {
+	public Response<OrderDetailResponse> getOrder(
+		@PathVariable Long orderId,
+		@AuthenticationPrincipal AuthUser authUser
+	) {
 		return Response.of(orderService.getOrder(orderId, authUser));
 	}
 

--- a/src/main/java/com/example/ddakdaegi/domain/order/dto/request/CreateOrderRequest.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/dto/request/CreateOrderRequest.java
@@ -1,5 +1,7 @@
 package com.example.ddakdaegi.domain.order.dto.request;
 
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,6 +12,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CreateOrderRequest {
 
+	@NotNull
+	@Size(min = 1)
 	private List<PromotionProductRequest> promotionProductRequests;
 
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderPromotionProductDto.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderPromotionProductDto.java
@@ -11,13 +11,32 @@ public class OrderPromotionProductDto {
 	private final PromotionProductDto promotionProduct;
 	private final Long quantity;
 
-	public OrderPromotionProductDto(OrderPromotionProduct orderPromotionProduct) {
-		this.orderPromotionProductId = orderPromotionProduct.getId();
+	private OrderPromotionProductDto(
+		Long orderPromotionProductId,
+		OrderPromotionProduct orderPromotionProduct,
+		Long quantity
+	) {
+		this.orderPromotionProductId = orderPromotionProductId;
 		this.promotionProduct = PromotionProductDto.of(orderPromotionProduct);
-		this.quantity = orderPromotionProduct.getQuantity();
+		this.quantity = quantity;
+	}
+
+	// Querydsl 사용을 위한 생성자
+	public OrderPromotionProductDto(
+		Long orderPromotionProductId,
+		PromotionProductDto promotionProductDto,
+		Long quantity
+	) {
+		this.orderPromotionProductId = orderPromotionProductId;
+		this.promotionProduct = promotionProductDto;
+		this.quantity = quantity;
 	}
 
 	public static OrderPromotionProductDto of(OrderPromotionProduct orderPromotionProduct) {
-		return new OrderPromotionProductDto(orderPromotionProduct);
+		return new OrderPromotionProductDto(
+			orderPromotionProduct.getId(),
+			orderPromotionProduct,
+			orderPromotionProduct.getQuantity()
+		);
 	}
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/dto/response/OrderResponse.java
@@ -11,13 +11,18 @@ import lombok.Getter;
 public class OrderResponse {
 
 	private final Long orderId;
-	private final List<OrderPromotionProductDto> orderPromotionProductDtos;
 	private final Long totalPrice;
 	private final OrderStatus status;
 	private final LocalDateTime orderCompletionTime;
+	private final List<OrderPromotionProductDto> orderPromotionProductDtos;
 
-	public OrderResponse(Long orderId, List<OrderPromotionProductDto> orderPromotionProductDtos, Long totalPrice,
-		OrderStatus status, LocalDateTime orderCompletionTime) {
+	public OrderResponse(
+		Long orderId,
+		Long totalPrice,
+		OrderStatus status,
+		LocalDateTime orderCompletionTime,
+		List<OrderPromotionProductDto> orderPromotionProductDtos
+	) {
 		this.orderId = orderId;
 		this.orderPromotionProductDtos = orderPromotionProductDtos;
 		this.totalPrice = totalPrice;
@@ -30,11 +35,11 @@ public class OrderResponse {
 			orderPromotionProducts.stream().map(OrderPromotionProductDto::of).toList();
 
 		return new OrderResponse(
-			order.getId(), orderPromotionProductDtos, order.getTotalPrice(), order.getStatus(), order.getCreatedAt());
+			order.getId(), order.getTotalPrice(), order.getStatus(), order.getCreatedAt(), orderPromotionProductDtos);
 	}
 
 	public static OrderResponse ofDto(Order order, List<OrderPromotionProductDto> orderPromotionProductDtos) {
 		return new OrderResponse(
-			order.getId(), orderPromotionProductDtos, order.getTotalPrice(), order.getStatus(), order.getCreatedAt());
+			order.getId(), order.getTotalPrice(), order.getStatus(), order.getCreatedAt(), orderPromotionProductDtos);
 	}
 }

--- a/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/repository/OrderRepositoryCustomImpl.java
@@ -2,21 +2,24 @@ package com.example.ddakdaegi.domain.order.repository;
 
 import com.example.ddakdaegi.domain.order.dto.response.OrderPromotionProductDto;
 import com.example.ddakdaegi.domain.order.dto.response.OrderResponse;
-import com.example.ddakdaegi.domain.order.entity.Order;
 import com.example.ddakdaegi.domain.promotion.dto.response.PromotionProductDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import static com.example.ddakdaegi.domain.image.entity.QImage.image;
 import static com.example.ddakdaegi.domain.order.entity.QOrder.order;
 import static com.example.ddakdaegi.domain.order.entity.QOrderPromotionProduct.orderPromotionProduct;
+import static com.example.ddakdaegi.domain.product.entity.QProduct.product;
+import static com.example.ddakdaegi.domain.promotion.entity.QPromotionProduct.promotionProduct;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
@@ -25,8 +28,35 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 
 	@Override
 	public Page<OrderResponse> findOrders(Long memberId, Pageable pageable) {
-		List<Order> orders = queryFactory
-			.selectFrom(order)
+		List<OrderResponse> content = queryFactory
+			.select(
+				Projections.constructor(
+					OrderResponse.class,
+					order.id,
+					order.totalPrice,
+					order.status,
+					order.createdAt,
+					Projections.list(
+						Projections.constructor(
+							OrderPromotionProductDto.class,
+							orderPromotionProduct.id,
+							Projections.constructor(
+								PromotionProductDto.class,
+								promotionProduct.id,
+								product.name,
+								image.imageUrl,
+								promotionProduct.price
+							),
+							orderPromotionProduct.quantity
+						)
+					)
+				)
+			)
+			.from(order)
+			.join(orderPromotionProduct).on(order.id.eq(orderPromotionProduct.order.id))
+			.join(orderPromotionProduct.promotionProduct, promotionProduct)
+			.join(promotionProduct.product, product)
+			.join(product.image, image)
 			.where(order.member.id.eq(memberId))
 			.orderBy(order.createdAt.desc())
 			.offset(pageable.getOffset())
@@ -38,30 +68,6 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
 			.from(order)
 			.where(order.member.id.eq(memberId))
 			.fetchOne();
-
-		List<OrderResponse> content = orders.stream()
-			.map(o -> {
-				List<OrderPromotionProductDto> orderPromotionProductDtos = queryFactory
-					.select(
-						Projections.constructor(
-							OrderPromotionProductDto.class,
-							orderPromotionProduct.id,
-							Projections.constructor(
-								PromotionProductDto.class,
-								orderPromotionProduct.promotionProduct.id,
-								orderPromotionProduct.promotionProduct.product.name,
-								orderPromotionProduct.promotionProduct.product.image,
-								orderPromotionProduct.promotionProduct.product.price
-							),
-							orderPromotionProduct.quantity
-						)
-					)
-					.from(orderPromotionProduct)
-					.where(orderPromotionProduct.order.id.eq(o.getId()))
-					.fetch();
-
-				return OrderResponse.ofDto(o, orderPromotionProductDtos);
-			}).collect(Collectors.toList());
 
 		return new PageImpl<>(content, pageable, totalCount != null ? totalCount : 0);
 	}

--- a/src/main/java/com/example/ddakdaegi/domain/order/service/StockService.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/service/StockService.java
@@ -21,6 +21,10 @@ public class StockService {
 
 	@Transactional
 	public StockResponse decreaseStockAndCalculateTotalPrice(List<PromotionProductRequest> promotionProductRequests) {
+		if (promotionProductRequests.isEmpty()) {
+			throw new RuntimeException("잘못된 요청입니다");
+		}
+
 		List<Long> promotionProductIds = promotionProductRequests.stream()
 			.map(PromotionProductRequest::getPromotionProductId)
 			.toList();
@@ -30,6 +34,10 @@ public class StockService {
 				Collectors.toMap(PromotionProductRequest::getPromotionProductId, PromotionProductRequest::getQuantity));
 
 		List<PromotionProduct> promotionProducts = promotionProductRepository.findAllByIdIn(promotionProductIds);
+
+		if (promotionProducts.isEmpty()) {
+			throw new RuntimeException("이벤트 상품을 찾을 수 없습니다");
+		}
 
 		long totalPrice = 0L;
 

--- a/src/main/java/com/example/ddakdaegi/domain/promotion/repository/PromotionProductRepository.java
+++ b/src/main/java/com/example/ddakdaegi/domain/promotion/repository/PromotionProductRepository.java
@@ -1,11 +1,14 @@
 package com.example.ddakdaegi.domain.promotion.repository;
 
 import com.example.ddakdaegi.domain.promotion.entity.PromotionProduct;
+import jakarta.persistence.LockModeType;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface PromotionProductRepository extends JpaRepository<PromotionProduct, Long> {
 
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	List<PromotionProduct> findAllByIdIn(Collection<Long> ids);
 }


### PR DESCRIPTION
## 📌 PR 요약
- 동시성 제어 및 Querydsl 코드 수정

## 🔗 관련 이슈
- ref #30

## 🛠️ 변경 사항
- 동시성 문제가 발생하는 부분에 DB Lock 추가
- CreateOrderRequest 필드에 검증 추가
- Querydsl 코드 수정
- constructor 프로젝션 사용 시 순서 및 타입 불일치가 발생하는 부분 수정

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

| 기능 | 스크린샷 |
| --- | --- |
| 동시성 제어 성공 | ![image](https://github.com/user-attachments/assets/aea8cd12-7f50-4044-985d-c87901703c42) |
| 동시성 제어 로직 | ![image](https://github.com/user-attachments/assets/8ed423a9-53b6-4ed2-a32d-73a566330b68) |

## ⚠️ 주의 사항 (선택)

- 프로모션 재고 100개, threadPool 100개 connectionPool 10개로 실행 했습니다.
- 이전에 진행하지 못한 테스트 모두 진행 후 해당 PR에 첨부 하였습니다.
- DB 락을 걸어 동시성 문제를 해결할 때 가장 효과적인 위치가 재고 감소 로직에 들어가기 전에 엔티티를 DB에서 읽어오는 시점에 락을 획득하는 것이기 때문에 해당 위치에 락을 설정했습니다.
   - 동시 업데이트 방지 (조회 시 비관적 락을 얻으면 다른 트랜잭션이 같은 행에 접근할 때까지 대기)

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.