### PR TITLE
Refactor: 동시성 제어 - Redis Lock

### DIFF
--- a/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
@@ -5,9 +5,9 @@ import com.example.ddakdaegi.domain.order.dto.response.OrderDetailResponse;
 import com.example.ddakdaegi.domain.order.dto.response.OrderResponse;
 import com.example.ddakdaegi.domain.order.dto.response.StockResponse;
 import com.example.ddakdaegi.domain.order.service.OrderService;
-import com.example.ddakdaegi.domain.order.service.StockService;
 import com.example.ddakdaegi.global.common.dto.AuthUser;
 import com.example.ddakdaegi.global.common.response.Response;
+import com.example.ddakdaegi.global.util.lock.LettuceLockStockFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
 	private final OrderService orderService;
-	private final StockService stockService;
+	private final LettuceLockStockFacade stockFacade;
 
 	@PostMapping("/v1/orders")
 	public Response<OrderResponse> createOrder(
@@ -36,7 +36,7 @@ public class OrderController {
 		@Valid @RequestBody CreateOrderRequest request
 	) {
 		StockResponse stockResponse =
-			stockService.decreaseStockAndCalculateTotalPrice(request.getPromotionProductRequests());
+			stockFacade.lockAndDecreaseStock(request.getPromotionId(), request.getPromotionProductRequests());
 
 		OrderResponse orderResponse =
 			orderService.createOrder(authUser, stockResponse);

--- a/src/main/java/com/example/ddakdaegi/domain/order/dto/request/CreateOrderRequest.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/dto/request/CreateOrderRequest.java
@@ -13,6 +13,9 @@ import lombok.NoArgsConstructor;
 public class CreateOrderRequest {
 
 	@NotNull
+	private Long promotionId;
+
+	@NotNull
 	@Size(min = 1)
 	private List<PromotionProductRequest> promotionProductRequests;
 

--- a/src/main/java/com/example/ddakdaegi/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/service/OrderService.java
@@ -11,6 +11,7 @@ import com.example.ddakdaegi.domain.order.repository.OrderPromotionProductReposi
 import com.example.ddakdaegi.domain.order.repository.OrderRepository;
 import com.example.ddakdaegi.domain.promotion.entity.PromotionProduct;
 import com.example.ddakdaegi.global.common.dto.AuthUser;
+import com.example.ddakdaegi.global.common.exception.BaseException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.ddakdaegi.global.common.exception.enums.ErrorCode.NOT_FOUND_MEMBER;
+import static com.example.ddakdaegi.global.common.exception.enums.ErrorCode.NOT_FOUND_ORDER;
 
 @Slf4j
 @Service
@@ -34,7 +38,7 @@ public class OrderService {
 	public OrderResponse createOrder(AuthUser authUser, StockResponse stockResponse) {
 
 		Member getMember = memberRepository.findById(authUser.getId())
-			.orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없음"));
+			.orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
 
 		Order newOrder = Order.of(getMember, stockResponse.getTotalPrice());
 		orderRepository.save(newOrder);
@@ -52,10 +56,10 @@ public class OrderService {
 	@Transactional(readOnly = true)
 	public OrderDetailResponse getOrder(Long orderId, AuthUser authUser) {
 		Member member = memberRepository.findById(authUser.getId())
-			.orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없음"));
+			.orElseThrow(() -> new BaseException(NOT_FOUND_MEMBER));
 
 		Order getOrder = orderRepository.findByOrderIdAndMemberId(orderId, authUser.getId())
-			.orElseThrow(() -> new RuntimeException("주문을 찾을 수 없음"));
+			.orElseThrow(() -> new BaseException(NOT_FOUND_ORDER));
 
 		List<OrderPromotionProduct> getOrderPromotionProduct = orderPromotionProductRepository.findByOrderId(orderId);
 		return OrderDetailResponse.of(getOrder, member, getOrderPromotionProduct);
@@ -69,7 +73,7 @@ public class OrderService {
 	@Transactional
 	public void cancelOrder(Long orderId, AuthUser authUser) {
 		Order getOrder = orderRepository.findByOrderIdAndMemberId(orderId, authUser.getId())
-			.orElseThrow(() -> new RuntimeException("사용자의 주문을 찾을 수 없음"));
+			.orElseThrow(() -> new BaseException(NOT_FOUND_ORDER));
 
 		List<OrderPromotionProduct> getOrderPromotionProduct = orderPromotionProductRepository.findByOrderId(orderId);
 

--- a/src/main/java/com/example/ddakdaegi/domain/order/service/StockService.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/service/StockService.java
@@ -4,6 +4,8 @@ import com.example.ddakdaegi.domain.order.dto.request.PromotionProductRequest;
 import com.example.ddakdaegi.domain.order.dto.response.StockResponse;
 import com.example.ddakdaegi.domain.promotion.entity.PromotionProduct;
 import com.example.ddakdaegi.domain.promotion.repository.PromotionProductRepository;
+import com.example.ddakdaegi.domain.promotion.repository.PromotionRepository;
+import com.example.ddakdaegi.global.common.exception.BaseException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -12,17 +14,29 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.example.ddakdaegi.global.common.exception.enums.ErrorCode.INSUFFICIENT_PROMOTION_PRODUCT_STOCK;
+import static com.example.ddakdaegi.global.common.exception.enums.ErrorCode.NOT_FOUND_PROMOTION_PRODUCT;
+import static com.example.ddakdaegi.global.common.exception.enums.ErrorCode.PROMOTION_NOT_STARTED;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class StockService {
 
 	private final PromotionProductRepository promotionProductRepository;
+	private final PromotionRepository promotionRepository;
 
 	@Transactional
-	public StockResponse decreaseStockAndCalculateTotalPrice(List<PromotionProductRequest> promotionProductRequests) {
+	public StockResponse decreaseStockAndCalculateTotalPrice(
+		Long promotionId,
+		List<PromotionProductRequest> promotionProductRequests
+	) {
+		if (!promotionRepository.promotionIsActive(promotionId)) {
+			throw new BaseException(PROMOTION_NOT_STARTED);
+		}
+
 		if (promotionProductRequests.isEmpty()) {
-			throw new RuntimeException("잘못된 요청입니다");
+			throw new BaseException(NOT_FOUND_PROMOTION_PRODUCT);
 		}
 
 		List<Long> promotionProductIds = promotionProductRequests.stream()
@@ -36,20 +50,20 @@ public class StockService {
 		List<PromotionProduct> promotionProducts = promotionProductRepository.findAllByIdIn(promotionProductIds);
 
 		if (promotionProducts.isEmpty()) {
-			throw new RuntimeException("이벤트 상품을 찾을 수 없습니다");
+			throw new BaseException(NOT_FOUND_PROMOTION_PRODUCT);
 		}
 
-		long totalPrice = 0L;
-
-		for (PromotionProduct promotionProduct : promotionProducts) {
-			Long quantity = promotionProductIdToQuantityMap.get(promotionProduct.getId());
-			if (promotionProduct.getStock() < quantity) {
-				throw new RuntimeException("재고가 부족합니다.");
-			}
-			promotionProduct.decreaseStock(quantity);
-			log.info("현재 재고 수량: {}", promotionProduct.getStock());
-			totalPrice += quantity * promotionProduct.getPrice();
-		}
+		long totalPrice = promotionProducts.stream()
+			.mapToLong(promotionProduct -> {
+				Long quantity = promotionProductIdToQuantityMap.get(promotionProduct.getId());
+				if (promotionProduct.getStock() < quantity) {
+					throw new BaseException(INSUFFICIENT_PROMOTION_PRODUCT_STOCK);
+				}
+				promotionProduct.decreaseStock(quantity);
+				log.info("재고 ID: {}, STOCK: {}, THREAD NAME: {}", promotionProduct.getId(),
+					promotionProduct.getStock(), Thread.currentThread().getName());
+				return quantity * promotionProduct.getPrice();
+			}).sum();
 
 		return StockResponse.of(totalPrice, promotionProductIdToQuantityMap, promotionProducts);
 	}

--- a/src/main/java/com/example/ddakdaegi/domain/promotion/repository/PromotionProductRepository.java
+++ b/src/main/java/com/example/ddakdaegi/domain/promotion/repository/PromotionProductRepository.java
@@ -1,14 +1,11 @@
 package com.example.ddakdaegi.domain.promotion.repository;
 
 import com.example.ddakdaegi.domain.promotion.entity.PromotionProduct;
-import jakarta.persistence.LockModeType;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 
 public interface PromotionProductRepository extends JpaRepository<PromotionProduct, Long> {
 
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	List<PromotionProduct> findAllByIdIn(Collection<Long> ids);
 }

--- a/src/main/java/com/example/ddakdaegi/domain/promotion/repository/PromotionRepository.java
+++ b/src/main/java/com/example/ddakdaegi/domain/promotion/repository/PromotionRepository.java
@@ -2,7 +2,11 @@ package com.example.ddakdaegi.domain.promotion.repository;
 
 import com.example.ddakdaegi.domain.promotion.entity.Promotion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PromotionRepository extends JpaRepository<Promotion, Long> {
 
+	@Query("select p.isActive from Promotion p where p.id = :promotionId")
+	Boolean promotionIsActive(@Param("promotionId") Long promotionId);
 }

--- a/src/main/java/com/example/ddakdaegi/global/common/exception/enums/ErrorCode.java
+++ b/src/main/java/com/example/ddakdaegi/global/common/exception/enums/ErrorCode.java
@@ -23,6 +23,11 @@ public enum ErrorCode {
 	NOT_FOUND_IMAGE(HttpStatus.BAD_REQUEST, "존재하지 않는 이미지 입니다."),
 
 	// order 예외처리
+	NOT_FOUND_ORDER(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
+	EMPTY_PROMOTION_PRODUCT_REQUEST(HttpStatus.BAD_REQUEST, "프로모션 상품 요청 리스트가 비어있습니다."),
+	INSUFFICIENT_PROMOTION_PRODUCT_STOCK(HttpStatus.BAD_REQUEST, "이벤트 상품의 재고가 없습니다."),
+	LOCK_ACQUISITION_INTERRUPTED(HttpStatus.INTERNAL_SERVER_ERROR, "Lock 획득 대기 중 인터럽트 되었습니다."),
+	PROMOTION_NOT_STARTED(HttpStatus.BAD_REQUEST, "아직 시작하지 않은 프로모션입니다."),
 
 	// product 예외처리
 	SOLD_OUT_SAME_FLAG(HttpStatus.BAD_REQUEST, "상품판매 상태가 요청하신 값으로 이미 설정되어 있습니다."),
@@ -31,6 +36,7 @@ public enum ErrorCode {
 
 	// promotion 예외처리
 	NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "상품을 찾을 수 없습니다."),
+	NOT_FOUND_PROMOTION_PRODUCT(HttpStatus.NOT_FOUND, "프로모션 상품을 찾을 수 없습니다."),
 	SOLD_OUT(HttpStatus.BAD_REQUEST, "해당 상품은 품절 상태입니다."),
 	OVER_STOCK(HttpStatus.BAD_REQUEST, "프로모션 재고가 상품 보유 재고보다 많을 수 없습니다."),
 	WRONG_POLICY(HttpStatus.BAD_REQUEST, "잘못된 할인 정책입니다."),
@@ -38,7 +44,7 @@ public enum ErrorCode {
 	INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "종료일이 시작일보다 먼저 올 수 없습니다."),
 
 	TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "잘못된 타입 입니다."),
-	SERVER_NOT_WORK(HttpStatus.INTERNAL_SERVER_ERROR, "서버문제로인해 실패했습니다.");
+	SERVER_NOT_WORK(HttpStatus.INTERNAL_SERVER_ERROR, "서버 문제로 인해 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/example/ddakdaegi/global/util/lock/LettuceLockStockFacade.java
+++ b/src/main/java/com/example/ddakdaegi/global/util/lock/LettuceLockStockFacade.java
@@ -1,0 +1,52 @@
+package com.example.ddakdaegi.global.util.lock;
+
+import com.example.ddakdaegi.domain.order.dto.request.PromotionProductRequest;
+import com.example.ddakdaegi.domain.order.dto.response.StockResponse;
+import com.example.ddakdaegi.domain.order.service.StockService;
+import com.example.ddakdaegi.global.common.exception.BaseException;
+import com.example.ddakdaegi.global.common.exception.enums.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LettuceLockStockFacade {
+
+	private final StockService stockService;
+	private final RedisLockRepository redisLockRepository;
+
+	public StockResponse lockAndDecreaseStock(Long promotionId, List<PromotionProductRequest> requests) {
+		List<String> keys = requests.stream()
+			.map(PromotionProductRequest::getPromotionProductId)
+			.sorted()
+			.map(id -> "PromotionProduct:" + id + ":stock")
+			.toList();
+
+		List<String> acquiredKeys = new ArrayList<>();
+
+		try {
+			for (String key : keys) {
+				log.info("Lock 획득 준비: {} - Thread: {}", key, Thread.currentThread().getName());
+				while (!redisLockRepository.lock(key)) {
+					log.info("Lock 획득 대기 중: {} - Thread: {}", key, Thread.currentThread().getName());
+					Thread.sleep(200);
+				}
+				log.info("Lock 획득 성공: {} - Thread: {}", key, Thread.currentThread().getName());
+				acquiredKeys.add(key);
+			}
+
+			return stockService.decreaseStockAndCalculateTotalPrice(promotionId, requests);
+		} catch (InterruptedException e) {
+			log.error("[InterruptedException]: ", e);
+			throw new BaseException(ErrorCode.LOCK_ACQUISITION_INTERRUPTED);
+		} finally {
+			// 획득한 모든 락 해제
+			acquiredKeys.forEach(redisLockRepository::unlock);
+		}
+	}
+
+}

--- a/src/main/java/com/example/ddakdaegi/global/util/lock/RedisLockRepository.java
+++ b/src/main/java/com/example/ddakdaegi/global/util/lock/RedisLockRepository.java
@@ -1,0 +1,24 @@
+package com.example.ddakdaegi.global.util.lock;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisLockRepository {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public Boolean lock(Object key) {
+		return redisTemplate
+			.opsForValue()
+			.setIfAbsent(key.toString(), "lock", Duration.ofMillis(3000));
+	}
+
+	public Boolean unlock(Object key) {
+		return redisTemplate.delete(key.toString());
+	}
+
+}


### PR DESCRIPTION
## 📌 PR 요약
- 동시성 제어 - Redis Lock (lettuce)

## 🔗 관련 이슈
- ref #30
- closed #31

## 🛠️ 변경 사항
- Redis(Lettuce) 분산락(Spin Lock)으로 동시성 제어
- 프로모션의 isActive 값에 따른 제어문 추가
- 요청 순서대로 값을 처리하지는 않음
- `RuntimeException` -> `BaseException`으로 수정

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

| 기능 | 스크린샷 |
| --- | --- |
| Redis Lock 설정 이후 테스트 코드 실행 결과 | ![image](https://github.com/user-attachments/assets/0a628c0f-f665-418e-91d7-a495b0e2354a) |

## ⚠️ 주의 사항 (선택)
리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.