### PR TITLE
Refactor: 동시성 제어 - AOP 방식으로 Redis Lock 적용

### DIFF
--- a/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/controller/OrderController.java
@@ -5,9 +5,9 @@ import com.example.ddakdaegi.domain.order.dto.response.OrderDetailResponse;
 import com.example.ddakdaegi.domain.order.dto.response.OrderResponse;
 import com.example.ddakdaegi.domain.order.dto.response.StockResponse;
 import com.example.ddakdaegi.domain.order.service.OrderService;
+import com.example.ddakdaegi.domain.order.service.StockService;
 import com.example.ddakdaegi.global.common.dto.AuthUser;
 import com.example.ddakdaegi.global.common.response.Response;
-import com.example.ddakdaegi.global.util.lock.RedissonLockStockFacade;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class OrderController {
 
 	private final OrderService orderService;
-	private final RedissonLockStockFacade stockFacade;
+	private final StockService stockService;
 
 	@PostMapping("/v1/orders")
 	public Response<OrderResponse> createOrder(
@@ -36,7 +36,8 @@ public class OrderController {
 		@Valid @RequestBody CreateOrderRequest request
 	) {
 		StockResponse stockResponse =
-			stockFacade.lockAndDecreaseStock(request.getPromotionId(), request.getPromotionProductRequests());
+			stockService.decreaseStockAndCalculateTotalPrice(
+				request.getPromotionId(), request.getPromotionProductRequests());
 
 		OrderResponse orderResponse =
 			orderService.createOrder(authUser, stockResponse);

--- a/src/main/java/com/example/ddakdaegi/domain/order/service/StockService.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/service/StockService.java
@@ -5,6 +5,7 @@ import com.example.ddakdaegi.domain.order.dto.response.StockResponse;
 import com.example.ddakdaegi.domain.promotion.entity.PromotionProduct;
 import com.example.ddakdaegi.domain.promotion.repository.PromotionProductRepository;
 import com.example.ddakdaegi.domain.promotion.repository.PromotionRepository;
+import com.example.ddakdaegi.global.common.annotation.Locked;
 import com.example.ddakdaegi.global.common.exception.BaseException;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ public class StockService {
 	private final PromotionProductRepository promotionProductRepository;
 	private final PromotionRepository promotionRepository;
 
+	@Locked
 	@Transactional
 	public StockResponse decreaseStockAndCalculateTotalPrice(
 		Long promotionId,

--- a/src/main/java/com/example/ddakdaegi/domain/order/service/StockService.java
+++ b/src/main/java/com/example/ddakdaegi/domain/order/service/StockService.java
@@ -35,10 +35,6 @@ public class StockService {
 			throw new BaseException(PROMOTION_NOT_STARTED);
 		}
 
-		if (promotionProductRequests.isEmpty()) {
-			throw new BaseException(NOT_FOUND_PROMOTION_PRODUCT);
-		}
-
 		List<Long> promotionProductIds = promotionProductRequests.stream()
 			.map(PromotionProductRequest::getPromotionProductId)
 			.toList();

--- a/src/main/java/com/example/ddakdaegi/global/common/annotation/Locked.java
+++ b/src/main/java/com/example/ddakdaegi/global/common/annotation/Locked.java
@@ -1,0 +1,12 @@
+package com.example.ddakdaegi.global.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Locked {
+
+}

--- a/src/main/java/com/example/ddakdaegi/global/common/aspect/StockLockAspect.java
+++ b/src/main/java/com/example/ddakdaegi/global/common/aspect/StockLockAspect.java
@@ -1,0 +1,72 @@
+package com.example.ddakdaegi.global.common.aspect;
+
+import com.example.ddakdaegi.domain.order.dto.request.PromotionProductRequest;
+import com.example.ddakdaegi.global.common.exception.BaseException;
+import com.example.ddakdaegi.global.common.exception.enums.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import static com.example.ddakdaegi.global.common.exception.enums.ErrorCode.LOCK_ACQUISITION_FAILED;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class StockLockAspect {
+
+	private final RedissonClient redissonClient;
+
+	@Around("execution(* com.example.ddakdaegi.domain.order.service.StockService.decreaseStockAndCalculateTotalPrice(..))")
+	public Object lockAdvice(ProceedingJoinPoint joinPoint) throws Throwable {
+		log.info("AOP Lock 로직 시작");
+
+		Object[] args = joinPoint.getArgs();
+		Long promotionId = (Long) args[0];
+		List<PromotionProductRequest> requests = (List<PromotionProductRequest>) args[1];
+
+		List<String> keys = requests.stream()
+			.map(PromotionProductRequest::getPromotionProductId)
+			.sorted()
+			.map(id -> "PromotionProduct:" + id + ":stock")
+			.toList();
+
+		List<RLock> acquiredLocks = new ArrayList<>();
+		try {
+			for (String key : keys) {
+				log.info("Lock 획득 준비: {} - Thread: {}", key, Thread.currentThread().getName());
+				RLock fairLock = redissonClient.getFairLock(key);
+				boolean available = fairLock.tryLock(1000, 100, TimeUnit.MILLISECONDS);
+				if (!available) {
+					log.info("Lock 획득 실패: {} - Thread: {}", key, Thread.currentThread().getName());
+					throw new BaseException(LOCK_ACQUISITION_FAILED);
+				}
+				log.info("Lock 획득 성공: {} - Thread: {}", key, Thread.currentThread().getName());
+				acquiredLocks.add(fairLock);
+			}
+
+			return joinPoint.proceed(new Object[]{promotionId, requests});
+		} catch (InterruptedException e) {
+			log.error("[InterruptedException]: ", e);
+			throw new BaseException(ErrorCode.LOCK_ACQUISITION_INTERRUPTED);
+		} finally {
+			for (RLock acquiredLock : acquiredLocks) {
+				try {
+					acquiredLock.unlock();
+				} catch (Exception e) {
+					log.error("Lock 해제 중 예외 발생: ", e);
+				}
+			}
+			log.info("AOP Lock 로직 끝");
+		}
+	}
+
+}

--- a/src/main/java/com/example/ddakdaegi/global/common/aspect/StockLockAspect.java
+++ b/src/main/java/com/example/ddakdaegi/global/common/aspect/StockLockAspect.java
@@ -25,7 +25,7 @@ public class StockLockAspect {
 
 	private final RedissonClient redissonClient;
 
-	@Around("execution(* com.example.ddakdaegi.domain.order.service.StockService.decreaseStockAndCalculateTotalPrice(..))")
+	@Around("@annotation(com.example.ddakdaegi.global.common.annotation.Locked)")
 	public Object lockAdvice(ProceedingJoinPoint joinPoint) throws Throwable {
 		log.info("AOP Lock 로직 시작");
 

--- a/src/main/java/com/example/ddakdaegi/global/util/lock/RedisLockRepository.java
+++ b/src/main/java/com/example/ddakdaegi/global/util/lock/RedisLockRepository.java
@@ -17,8 +17,8 @@ public class RedisLockRepository {
 			.setIfAbsent(key.toString(), "lock", Duration.ofMillis(3000));
 	}
 
-	public Boolean unlock(Object key) {
-		return redisTemplate.delete(key.toString());
+	public void unlock(Object key) {
+		redisTemplate.delete(key.toString());
 	}
 
 }

--- a/src/test/java/com/example/ddakdaegi/domain/order/service/ConcurrencyStockServiceTest.java
+++ b/src/test/java/com/example/ddakdaegi/domain/order/service/ConcurrencyStockServiceTest.java
@@ -89,7 +89,7 @@ class ConcurrencyStockServiceTest {
 	}
 
 	@Test
-	void 동시성_제어가_안되는_테스트() throws InterruptedException {
+	void 동시_주문_재고관리_테스트() throws InterruptedException {
 
 		PromotionProduct promotionProduct = promotionProductRepository.findById(1L)
 			.orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_PROMOTION_PRODUCT));

--- a/src/test/java/com/example/ddakdaegi/global/util/lock/LettuceLockStockFacadeTest.java
+++ b/src/test/java/com/example/ddakdaegi/global/util/lock/LettuceLockStockFacadeTest.java
@@ -91,7 +91,7 @@ class LettuceLockStockFacadeTest {
 
 	@Test
 	@DisplayName("동시에 여러 주문이 들어올 때 재고 관리 동시성 테스트")
-	void 동시주문_재고관리_테스트() throws InterruptedException {
+	void 동시_주문_재고관리_테스트() throws InterruptedException {
 
 		PromotionProduct promotionProduct = promotionProductRepository.findById(1L)
 			.orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_PROMOTION_PRODUCT));

--- a/src/test/java/com/example/ddakdaegi/global/util/lock/RedissonLockStockFacadeTest.java
+++ b/src/test/java/com/example/ddakdaegi/global/util/lock/RedissonLockStockFacadeTest.java
@@ -91,7 +91,7 @@ class RedissonLockStockFacadeTest {
 
 	@Test
 	@DisplayName("동시에 여러 주문이 들어올 때 재고 관리 동시성 테스트")
-	void 동시주문_재고관리_테스트() throws InterruptedException {
+	void 동시_주문_재고관리_테스트() throws InterruptedException {
 
 		PromotionProduct promotionProduct = promotionProductRepository.findById(1L)
 			.orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_PROMOTION_PRODUCT));
@@ -117,7 +117,7 @@ class RedissonLockStockFacadeTest {
 			int num = 1 + i;
 			executorService.execute(() -> {
 				try {
-					Thread.sleep(320);
+					Thread.sleep(100 % num * 100);
 					redissonLockStockFacade.lockAndDecreaseStock(promotion.getId(), request);
 					successCount.incrementAndGet();
 				} catch (Exception e) {


### PR DESCRIPTION
## 📌 PR 요약
- 동시성 제어 - AOP 방식으로 Redis Lock 적용

## 🔗 관련 이슈
- closed #30

## 🛠️ 변경 사항
- `OrderController`가 `StockService`를 호출하도록 변경
- `RedisLockRepository.unlock()`메서드의 반환값이 사용되지 않아서 void로 변경

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

| 기능 | 스크린샷 |
| --- | --- |
| AOP 적용 후 실행 결과 (1) | ![스크린샷 2025-03-28 165346](https://github.com/user-attachments/assets/b23e1615-521b-4208-aa4a-aeba70e1b770) |
| AOP 적용 후 실행 결과 (2) | ![스크린샷 2025-03-28 165308](https://github.com/user-attachments/assets/f5e4fe29-a61e-41f9-817e-a34acc94265d) |

## ⚠️ 주의 사항 (선택)

stockService에 AOP가 적용되어서 동시성 테스트 코드 실행 시 콘솔 창에 출력되는 내용이 다소 차이가 있을 수 있습니다.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.